### PR TITLE
42 add faceedge sizing options based on new selector

### DIFF
--- a/src/GeometryCore/CMakeLists.txt
+++ b/src/GeometryCore/CMakeLists.txt
@@ -1,5 +1,6 @@
 ADD_LIBRARY(GeometryCore 
     Geometry/Geometry.cpp
+    Geometry/TagMap.cpp
     QVTKProgressBar/ProgressBarPlugin.hpp
     GeometryImporter/GeometryImporter.cpp
     GeometryImporter/STEPImporter.cpp

--- a/src/GeometryCore/Geometry/Geometry.cpp
+++ b/src/GeometryCore/Geometry/Geometry.cpp
@@ -20,15 +20,3 @@ void GeometryCore::Geometry::importSTL(const std::string& filePath, QWidget* pro
         this->_tagMap.tagEntities(shape.second);
     }
 };
-
-std::vector<std::reference_wrapper<const TopoDS_Vertex>> GeometryCore::getShapeVertices(const TopoDS_Shape& shape){
-    std::vector<std::reference_wrapper<const TopoDS_Vertex>> vertices;
-    for (TopExp_Explorer vertexExplorer(shape, TopAbs_VERTEX);
-        vertexExplorer.More();
-        vertexExplorer.Next()){
-            const TopoDS_Vertex& vertex = TopoDS::Vertex(vertexExplorer.Current());
-            vertices.push_back(vertex);
-            }
-    return vertices;
-}
-

--- a/src/GeometryCore/Geometry/Geometry.cpp
+++ b/src/GeometryCore/Geometry/Geometry.cpp
@@ -20,3 +20,15 @@ void GeometryCore::Geometry::importSTL(const std::string& filePath, QWidget* pro
         this->_tagMap.tagEntities(shape.second);
     }
 };
+
+std::vector<std::reference_wrapper<const TopoDS_Vertex>> GeometryCore::getShapeVertices(const TopoDS_Shape& shape){
+    std::vector<std::reference_wrapper<const TopoDS_Vertex>> vertices;
+    for (TopExp_Explorer vertexExplorer(shape, TopAbs_VERTEX);
+        vertexExplorer.More();
+        vertexExplorer.Next()){
+            const TopoDS_Vertex& vertex = TopoDS::Vertex(vertexExplorer.Current());
+            vertices.push_back(vertex);
+            }
+    return vertices;
+}
+

--- a/src/GeometryCore/Geometry/Geometry.cpp
+++ b/src/GeometryCore/Geometry/Geometry.cpp
@@ -1,13 +1,22 @@
 #include "Geometry.h"
 
+GeometryCore::Geometry::Geometry(){};
+GeometryCore::Geometry::~Geometry(){};
+
 void GeometryCore::Geometry::importSTEP(const std::string& filePath, QWidget* progressBar){
 
     GeometryCore::STEPImporter importer;
     importer.import(filePath, progressBar);
     this->_shapesMap = std::move(importer.getPartsMap());
+    for(auto shape : _shapesMap){
+        this->_tagMap.tagEntities(shape.second);
+    }
 };
 void GeometryCore::Geometry::importSTL(const std::string& filePath, QWidget* progressBar){
     GeometryCore::STLImporter importer;
     importer.import(filePath, progressBar);
     this->_shapesMap = std::move(importer.getPartsMap());
+    for(auto shape : _shapesMap){
+        this->_tagMap.tagEntities(shape.second);
+    }
 };

--- a/src/GeometryCore/Geometry/Geometry.cpp
+++ b/src/GeometryCore/Geometry/Geometry.cpp
@@ -20,3 +20,18 @@ void GeometryCore::Geometry::importSTL(const std::string& filePath, QWidget* pro
         this->_tagMap.tagEntities(shape.second);
     }
 };
+
+std::vector<int> GeometryCore::Geometry::getShapeVerticesTags(const TopoDS_Shape& shape){
+    std::vector<int> vertexTags;
+    int vertex_tag;
+    TopExp_Explorer shapeExplorer(shape, TopAbs_VERTEX);
+    for(; shapeExplorer.More(); shapeExplorer.Next()) {
+        const TopoDS_Vertex& vertex = TopoDS::Vertex(shapeExplorer.Current());
+        vertex_tag = _tagMap.getTag(vertex);
+        vertexTags.push_back(vertex_tag);
+    }
+    std::sort(vertexTags.begin(), vertexTags.end());
+    vertexTags.erase(std::unique(vertexTags.begin(), vertexTags.end()), vertexTags.end());
+    return vertexTags;
+}
+

--- a/src/GeometryCore/Geometry/Geometry.h
+++ b/src/GeometryCore/Geometry/Geometry.h
@@ -5,23 +5,20 @@
 #include "STEPImporter.h"
 #include "STLImporter.h"
 #include "GeometryImporter.h"
+#include "TagMap.h"
 #include <TopTools_DataMapOfShapeInteger.hxx>
 #include <TopTools_DataMapOfIntegerShape.hxx>
 
+
 namespace GeometryCore {
-    enum class EntityType : int {
-        Vertex = 0,
-        Line = 1,
-        Face = 2,
-        Solid = 3,
-        NumEntityTypes = 4
-    };
 
     using namespace std::string_literals;
     using PartsMap = std::map<std::string, TopoDS_Shape>;
 
     class Geometry {
     public:
+        Geometry();
+        ~Geometry();
         const PartsMap& getShapesMap() const {return this->_shapesMap;};
 
         void importSTEP(const std::string& filePath, QWidget* progressBar);
@@ -30,6 +27,7 @@ namespace GeometryCore {
         
     private:
         PartsMap _shapesMap;
+        TagMap _tagMap;
     };
 };
 

--- a/src/GeometryCore/Geometry/Geometry.h
+++ b/src/GeometryCore/Geometry/Geometry.h
@@ -24,12 +24,13 @@ namespace GeometryCore {
         void importSTEP(const std::string& filePath, QWidget* progressBar);
         
         void importSTL(const std::string& filePath, QWidget* progressBar);
-        TagMap _tagMap;
-        
-        std::vector<std::reference_wrapper<const TopoDS_Vertex>> getShapeVertices(const TopoDS_Shape& shape);
 
+        std::vector<int> getShapeVerticesTags(const TopoDS_Shape& shape);
+
+        
     private:
         PartsMap _shapesMap;
+        TagMap _tagMap;
     };
 
     // Geometry utils 

--- a/src/GeometryCore/Geometry/Geometry.h
+++ b/src/GeometryCore/Geometry/Geometry.h
@@ -24,11 +24,14 @@ namespace GeometryCore {
         void importSTEP(const std::string& filePath, QWidget* progressBar);
         
         void importSTL(const std::string& filePath, QWidget* progressBar);
+        TagMap _tagMap;
         
     private:
         PartsMap _shapesMap;
-        TagMap _tagMap;
     };
+
+    // Geometry utils 
+    std::vector<std::reference_wrapper<const TopoDS_Vertex>> getShapeVertices(const TopoDS_Shape& shape);
 };
 
 

--- a/src/GeometryCore/Geometry/Geometry.h
+++ b/src/GeometryCore/Geometry/Geometry.h
@@ -26,12 +26,13 @@ namespace GeometryCore {
         void importSTL(const std::string& filePath, QWidget* progressBar);
         TagMap _tagMap;
         
+        std::vector<std::reference_wrapper<const TopoDS_Vertex>> getShapeVertices(const TopoDS_Shape& shape);
+
     private:
         PartsMap _shapesMap;
     };
 
     // Geometry utils 
-    std::vector<std::reference_wrapper<const TopoDS_Vertex>> getShapeVertices(const TopoDS_Shape& shape);
 };
 
 

--- a/src/GeometryCore/Geometry/TagMap.cpp
+++ b/src/GeometryCore/Geometry/TagMap.cpp
@@ -18,7 +18,7 @@ void GeometryCore::TagMap::tagShape(const TopoDS_Vertex& shape){
     if (!_vertexTagMap.IsBound(shape)){
         this->incrementMaxTag(EntityType::Vertex);
         int tag = this->getMaxTag(EntityType::Vertex);
-        std::cout<<"Tagging vertex with tag: " << tag <<std::endl;
+        // std::cout<<"Tagging vertex with tag: " << tag <<std::endl;
         this->_tagVertexMap.Bind(tag, shape);
         this->_vertexTagMap.Bind(shape, tag);
     }
@@ -104,6 +104,8 @@ TopoDS_Shape GeometryCore::TagMap::getShape(EntityType type, int tag) {
 }
 
 void GeometryCore::TagMap::tagEntities(const TopoDS_Shape& shape){
+    
+    TopExp_Explorer shapeExplorer;
     for(shapeExplorer.Init(shape, TopAbs_SOLID); shapeExplorer.More(); shapeExplorer.Next()){
         const TopoDS_Solid& solid = TopoDS::Solid(shapeExplorer.Current());
         this->tagShape(solid);

--- a/src/GeometryCore/Geometry/TagMap.cpp
+++ b/src/GeometryCore/Geometry/TagMap.cpp
@@ -1,5 +1,9 @@
 #include "TagMap.h"
 
+GeometryCore::TagMap::TagMap() {
+    std::fill(_maxEntityTags.begin(), _maxEntityTags.end(), 0);
+}
+
 int GeometryCore::TagMap::getMaxTag(EntityType type){
     return this->_maxEntityTags.at(static_cast<int>(type));
 }
@@ -13,7 +17,7 @@ void GeometryCore::TagMap::incrementMaxTag(EntityType type){
 void GeometryCore::TagMap::tagShape(const TopoDS_Vertex& shape){
     this->incrementMaxTag(EntityType::Vertex);
     int tag = this->getMaxTag(EntityType::Vertex);
-    // std::cout<<"Tagging vertex with tag: " << tag <<std::endl;
+    std::cout<<"Tagging vertex with tag: " << tag <<std::endl;
     this->_tagVertexMap.Bind(tag, shape);
     this->_vertexTagMap.Bind(shape, tag);
 }
@@ -27,7 +31,7 @@ void GeometryCore::TagMap::tagShape(const TopoDS_Edge& shape){
 void GeometryCore::TagMap::tagShape(const TopoDS_Face& shape){
     this->incrementMaxTag(EntityType::Face);
     int tag = this->getMaxTag(EntityType::Face);
-        // std::cout<<"Tagging face with tag: " << tag <<std::endl;
+    // std::cout<<"Tagging face with tag: " << tag <<std::endl;
     this->_tagFaceMap.Bind(tag, shape);
     this->_faceTagMap.Bind(shape, tag);
 }
@@ -39,7 +43,12 @@ void GeometryCore::TagMap::tagShape(const TopoDS_Solid& shape){
     this->_solidTagMap.Bind(shape, tag);
 }
 const int& GeometryCore::TagMap::getTag(const TopoDS_Vertex& shape){
-    return this->_vertexTagMap.Find(shape);
+    if (_vertexTagMap.IsBound(shape)){
+        return this->_vertexTagMap.Find(shape);
+    }else{
+        std::cout<<"Vertex not bound!";
+        return 0;
+    }
 }
 const int& GeometryCore::TagMap::getTag(const TopoDS_Edge& shape){
     return this->_edgeTagMap.Find(shape);

--- a/src/GeometryCore/Geometry/TagMap.cpp
+++ b/src/GeometryCore/Geometry/TagMap.cpp
@@ -15,32 +15,40 @@ void GeometryCore::TagMap::incrementMaxTag(EntityType type){
 }
 
 void GeometryCore::TagMap::tagShape(const TopoDS_Vertex& shape){
-    this->incrementMaxTag(EntityType::Vertex);
-    int tag = this->getMaxTag(EntityType::Vertex);
-    std::cout<<"Tagging vertex with tag: " << tag <<std::endl;
-    this->_tagVertexMap.Bind(tag, shape);
-    this->_vertexTagMap.Bind(shape, tag);
+    if (!_vertexTagMap.IsBound(shape)){
+        this->incrementMaxTag(EntityType::Vertex);
+        int tag = this->getMaxTag(EntityType::Vertex);
+        std::cout<<"Tagging vertex with tag: " << tag <<std::endl;
+        this->_tagVertexMap.Bind(tag, shape);
+        this->_vertexTagMap.Bind(shape, tag);
+    }
 }
 void GeometryCore::TagMap::tagShape(const TopoDS_Edge& shape){
-    this->incrementMaxTag(EntityType::Edge);
-    int tag = this->getMaxTag(EntityType::Edge);
-    // std::cout<<"Tagging edge with tag: " << tag <<std::endl;
-    this->_tagEdgeMap.Bind(tag, shape);
-    this->_edgeTagMap.Bind(shape, tag);
+    if (!_edgeTagMap.IsBound(shape)){
+        this->incrementMaxTag(EntityType::Edge);
+        int tag = this->getMaxTag(EntityType::Edge);
+        // std::cout<<"Tagging edge with tag: " << tag <<std::endl;
+        this->_tagEdgeMap.Bind(tag, shape);
+        this->_edgeTagMap.Bind(shape, tag);
+    }
 }
 void GeometryCore::TagMap::tagShape(const TopoDS_Face& shape){
-    this->incrementMaxTag(EntityType::Face);
-    int tag = this->getMaxTag(EntityType::Face);
-    // std::cout<<"Tagging face with tag: " << tag <<std::endl;
-    this->_tagFaceMap.Bind(tag, shape);
-    this->_faceTagMap.Bind(shape, tag);
+    if (!_faceTagMap.IsBound(shape)){
+        this->incrementMaxTag(EntityType::Face);
+        int tag = this->getMaxTag(EntityType::Face);
+        // std::cout<<"Tagging face with tag: " << tag <<std::endl;
+        this->_tagFaceMap.Bind(tag, shape);
+        this->_faceTagMap.Bind(shape, tag);
+    }
 }
 void GeometryCore::TagMap::tagShape(const TopoDS_Solid& shape){
-    this->incrementMaxTag(EntityType::Solid);
-    int tag = this->getMaxTag(EntityType::Solid);
-    // std::cout<<"Tagging solid with tag: " << tag <<std::endl;
-    this->_tagSolidMap.Bind(tag, shape);
-    this->_solidTagMap.Bind(shape, tag);
+    if (!_solidTagMap.IsBound(shape)){
+        this->incrementMaxTag(EntityType::Solid);
+        int tag = this->getMaxTag(EntityType::Solid);
+        // std::cout<<"Tagging solid with tag: " << tag <<std::endl;
+        this->_tagSolidMap.Bind(tag, shape);
+        this->_solidTagMap.Bind(shape, tag);
+    }
 }
 const int& GeometryCore::TagMap::getTag(const TopoDS_Vertex& shape){
     if (_vertexTagMap.IsBound(shape)){
@@ -96,22 +104,20 @@ TopoDS_Shape GeometryCore::TagMap::getShape(EntityType type, int tag) {
 }
 
 void GeometryCore::TagMap::tagEntities(const TopoDS_Shape& shape){
-    TopExp_Explorer entityExp;
-
-    for(entityExp.Init(shape, TopAbs_SOLID); entityExp.More(); entityExp.Next()){
-        TopoDS_Solid solid = TopoDS::Solid(entityExp.Current());
+    for(shapeExplorer.Init(shape, TopAbs_SOLID); shapeExplorer.More(); shapeExplorer.Next()){
+        const TopoDS_Solid& solid = TopoDS::Solid(shapeExplorer.Current());
         this->tagShape(solid);
     }
-    for(entityExp.Init(shape, TopAbs_FACE); entityExp.More(); entityExp.Next()){
-        TopoDS_Face face = TopoDS::Face(entityExp.Current());
+    for(shapeExplorer.Init(shape, TopAbs_FACE); shapeExplorer.More(); shapeExplorer.Next()){
+        const TopoDS_Face& face = TopoDS::Face(shapeExplorer.Current());
         this->tagShape(face);
     }
-    for(entityExp.Init(shape, TopAbs_EDGE); entityExp.More(); entityExp.Next()){
-        TopoDS_Edge edge = TopoDS::Edge(entityExp.Current());
+    for(shapeExplorer.Init(shape, TopAbs_EDGE); shapeExplorer.More(); shapeExplorer.Next()){
+        const TopoDS_Edge& edge = TopoDS::Edge(shapeExplorer.Current());
         this->tagShape(edge);
     }
-    for(entityExp.Init(shape, TopAbs_VERTEX); entityExp.More(); entityExp.Next()){
-        TopoDS_Vertex vertex = TopoDS::Vertex(entityExp.Current());
+    for(shapeExplorer.Init(shape, TopAbs_VERTEX); shapeExplorer.More(); shapeExplorer.Next()){
+        const TopoDS_Vertex& vertex = TopoDS::Vertex(shapeExplorer.Current());
         this->tagShape(vertex);
     }
 }

--- a/src/GeometryCore/Geometry/TagMap.h
+++ b/src/GeometryCore/Geometry/TagMap.h
@@ -45,12 +45,8 @@ namespace GeometryCore {
             const int& getTag(const TopoDS_Edge& shape);
             const int& getTag(const TopoDS_Vertex& shape);
 
-            TopExp_Explorer shapeExplorer;
-
         private:
             std::array<int, static_cast<size_t>(EntityType::EntityTypeCount)> _maxEntityTags;
-
-
 
             int getMaxTag(EntityType type);
             void setMaxTag(EntityType type, int tag);

--- a/src/GeometryCore/Geometry/TagMap.h
+++ b/src/GeometryCore/Geometry/TagMap.h
@@ -45,8 +45,12 @@ namespace GeometryCore {
             const int& getTag(const TopoDS_Edge& shape);
             const int& getTag(const TopoDS_Vertex& shape);
 
+            TopExp_Explorer shapeExplorer;
+
         private:
             std::array<int, static_cast<size_t>(EntityType::EntityTypeCount)> _maxEntityTags;
+
+
 
             int getMaxTag(EntityType type);
             void setMaxTag(EntityType type, int tag);

--- a/src/GeometryCore/Geometry/TagMap.h
+++ b/src/GeometryCore/Geometry/TagMap.h
@@ -28,6 +28,9 @@ namespace GeometryCore {
     class TagMap{
 
         public:
+
+            TagMap();
+
             void tagEntities(const TopoDS_Shape& shape);
             
             void tagShape(const TopoDS_Solid& shape);

--- a/src/MeshCore/CMakeLists.txt
+++ b/src/MeshCore/CMakeLists.txt
@@ -1,5 +1,6 @@
 ADD_LIBRARY(MeshCore 
     Mesh.cpp
+    MeshContainers.hpp
 )
 
 if(WIN32)

--- a/src/MeshCore/CMakeLists.txt
+++ b/src/MeshCore/CMakeLists.txt
@@ -3,13 +3,16 @@ ADD_LIBRARY(MeshCore
 )
 
 if(WIN32)
-    TARGET_LINK_LIBRARIES(MeshCore PUBLIC 
-)
+    TARGET_LINK_LIBRARIES(MeshCore PUBLIC
+        ${OpenCASCADE_LIBRARIES}
+        ${VTK_LIBRARIES}
+        )
 else()
     TARGET_LINK_LIBRARIES(MeshCore PUBLIC
-)
+        ${OCC_LIBRARIES}
+        ${VTK_LIBRARIES}
+        )
 endif()
-
 
 TARGET_INCLUDE_DIRECTORIES(MeshCore PUBLIC
     ${PRJ_SOURCE_DIR}/src/MeshCore

--- a/src/MeshCore/Mesh.cpp
+++ b/src/MeshCore/Mesh.cpp
@@ -1,1 +1,141 @@
 #include "Mesh.h"
+
+void MeshCore::Mesh::addSizing(std::vector<int> verticesTags, double size){
+    MeshSizing meshSizing(verticesTags, size);
+    _meshSizings.push_back(meshSizing);
+};
+
+void MeshCore::Mesh::genereateSurfaceMesh(){
+    gmsh::option::setNumber("Mesh.MeshSizeMin", 0.1);
+    gmsh::option::setNumber("Mesh.MeshSizeMax", 1);
+
+    for(const auto& meshSizing : _meshSizings){
+        gmsh::model::mesh::setSize(meshSizing.nodeTags,
+                                   meshSizing.elementSize);
+    }
+    gmsh::model::mesh::generate(2);
+    this->_polyData = createSurfaceMeshPolyData();
+    this->_meshActor = createMeshActor(_polyData);
+}
+
+vtkSmartPointer<vtkActor> MeshCore::Mesh::createMeshActor(vtkSmartPointer<vtkPolyData> polyData){
+        vtkSmartPointer<vtkPolyDataMapper> mapper = vtkSmartPointer<vtkPolyDataMapper>::New();
+        mapper->SetInputData(_polyData);
+        vtkSmartPointer<vtkActor> meshActor = vtkSmartPointer<vtkActor>::New();
+        meshActor->SetMapper(mapper);
+        meshActor->GetProperty()->EdgeVisibilityOn();
+        meshActor->GetProperty()->SetEdgeColor(0.0, 0.0, 0.0);
+        return meshActor;
+        }
+        
+vtkSmartPointer<vtkPolyData> MeshCore::Mesh::createSurfaceMeshPolyData(){
+    // extract nodes from gmsh model, and transfer them to vtkPoints container
+    // nodeTags is a vector containing node numbering (tag - hence the name)
+    // nodeCoords holds coordinates of each node [node_1_x, node_1_y, node_1_z, node_2_x, etc...]
+    #ifdef _WIN32
+    std::vector<unsigned long long> nodeTags;
+    #endif
+    #ifdef linux
+    std::vector<unsigned long> nodeTags;
+    #endif
+    std::vector<double> nodeCoords;
+    std::vector<double> parametricCoord;
+
+    gmsh::model::mesh::getNodes(nodeTags, nodeCoords, parametricCoord);
+
+    vtkSmartPointer<vtkPoints> vtkNodes = vtkSmartPointer<vtkPoints>::New();
+    int xNodeId, yNodeId, zNodeId;
+    for(size_t i = 0; i < nodeTags.size(); ++i)
+    {
+        xNodeId = i*3;
+        yNodeId = xNodeId + 1;
+        zNodeId = xNodeId + 2;
+        vtkNodes->InsertNextPoint(nodeCoords[xNodeId],
+                                    nodeCoords[yNodeId],
+                                    nodeCoords[zNodeId]);
+    }
+
+    // extract 3D elements from gmsh model, and transfer them to vtkCellArray container
+    // elementTypes is a vector containing types of elemnts in the mesh
+    // elementTags is a vevtor of length equal to elementTypes. It holds a vector of element
+    // ids (tags) for each element type. Ex elementTags[0].size() would return a total number
+    // of elements of type elementTags[0] (so far only tetras)
+    // elementNodeTags is a vevtor of length equal to elementTypes. For each type it stores
+    // a vector of node tags concatenated: [e1n1, e1n2, ..., e1nN, e2n1, ...]
+    // in our case we so far handle only tetrahedral elements (so 4 nodes per ele)
+
+    std::vector<int> _elementTypes;
+    std::vector<ElementType> elementTypes;
+
+    #ifdef _WIN32
+    std::vector<std::vector<unsigned long long>> elementTags;
+    std::vector<std::vector<unsigned long long>> elementNodeTags;
+    #endif
+    #ifdef linux
+    std::vector<std::vector<unsigned long>> elementTags;
+    std::vector<std::vector<unsigned long>> elementNodeTags;
+    #endif
+
+    gmsh::model::mesh::getElements(_elementTypes, elementTags, elementNodeTags, -1);
+
+    elementTypes.reserve(_elementTypes.size());
+    std::transform(_elementTypes.begin(), _elementTypes.end(), std::back_inserter(elementTypes),
+    [](int& elem){return static_cast<ElementType>(elem);});
+
+    struct ElementData {
+        ElementData() 
+            : nCellNodes(0), 
+            vtkCellType(0), 
+            vtkCells(vtkSmartPointer<vtkCellArray>::New()) {}
+
+        ElementData(int nNodes, int vtkType)
+            : nCellNodes(nNodes),
+            vtkCellType(vtkType),
+            vtkCells(vtkSmartPointer<vtkCellArray>::New()) {}
+
+    int nCellNodes;
+    vtkSmartPointer<vtkCellArray> vtkCells;
+    int vtkCellType;
+    };
+
+    std::map<ElementType, ElementData> elementDataMap = {
+        {ElementType::TETRA, {4, VTK_TETRA}},
+        {ElementType::TRIANGLE, {3, VTK_TRIANGLE}},
+        {ElementType::LINE, {2, VTK_LINE}}
+    };
+
+    std::vector<vtkIdType> currentElementNodeTags;
+    for(size_t i = 0; i < elementTypes.size(); ++i)
+    {
+        if(elementTypes[i]!=ElementType::POINT){
+            ElementData elementData = elementDataMap.at(elementTypes[i]);
+            auto nElements = elementTags[i].size();
+            auto nNodes = elementData.nCellNodes;
+            auto cellArray = elementData.vtkCells;
+            auto cellType = elementData.vtkCellType;
+
+            for(size_t elementId = 0; elementId < nElements; ++elementId){
+                auto startNodeIterator = std::make_move_iterator(elementNodeTags[i].begin() + elementId * nNodes);
+                auto endNodeIterator = std::make_move_iterator(elementNodeTags[i].begin() + (elementId + 1) * nNodes);
+
+                std::transform(startNodeIterator, endNodeIterator, std::back_inserter(currentElementNodeTags),
+                    [](auto nodeId) { return static_cast<vtkIdType>(nodeId - 1);});
+                cellArray->InsertNextCell(nNodes, currentElementNodeTags.data());
+                currentElementNodeTags.clear(); 
+            }
+        }
+    }
+    vtkSmartPointer<vtkPolyData> polyData = vtkSmartPointer<vtkPolyData>::New();
+    polyData->SetPoints(vtkNodes);
+    polyData->SetLines(elementDataMap.at(ElementType::LINE).vtkCells);
+    polyData->SetPolys(elementDataMap.at(ElementType::TRIANGLE).vtkCells);
+    return polyData;
+}
+
+MeshCore::MeshSizing::MeshSizing(std::vector<int> verticesTags, double size){
+    elementSize = size;
+    for(auto vertexTag : verticesTags){
+                std::pair<int, int> tagPair(0, vertexTag);
+                nodeTags.push_back(tagPair);
+            }
+};

--- a/src/MeshCore/Mesh.h
+++ b/src/MeshCore/Mesh.h
@@ -12,33 +12,38 @@
 #include <algorithm>
 #include <vector>
 
+#include <vtkSmartPointer.h>
 #include <vtkActor.h>
 #include <vtkCellArray.h>
 #include <vtkPoints.h>
 #include <vtkPolyData.h>
-#include <vtkSmartPointer.h>
-#include <vtkUnstructuredGrid.h>
-#include <vtkDataSetMapper.h>
-#include <vtkIdTypeArray.h>
-
+#include <vtkProperty.h>
+#include <vtkPolyData.h>
+#include <vtkPolyDataMapper.h>
 
 namespace MeshCore{
+
+    struct MeshSizing{
+        
+        MeshSizing(std::vector<int> verticesTags, double size);
+
+        double elementSize;
+        std::vector<std::pair<int, int>> nodeTags;
+    };
 
     class Mesh{
         public:
 
-            Mesh(){};
-            ~Mesh(){};
-
             vtkSmartPointer<vtkActor> getMeshActor(){return this->_meshActor;};
 
-            void addSizing(std::vector<int> nodeToSizeTags);
+            void addSizing(std::vector<int> verticesTags, double size);
             void genereateSurfaceMesh();
-            void generateVolumeMesh();
 
         private:
             
-            void updateMeshActor();
+            vtkSmartPointer<vtkPolyData> createSurfaceMeshPolyData();
+
+            vtkSmartPointer<vtkActor> createMeshActor(vtkSmartPointer<vtkPolyData> polyData);
 
             enum class ElementType : int {
                 TETRA = 4,
@@ -46,15 +51,16 @@ namespace MeshCore{
                 LINE = 1,
                 POINT = 15,
             };
-
-            vtkSmartPointer<vtkActor> _meshActor;
-
-            std::vector<std::pair<int, int>> _sizingTags;
+            std::vector<MeshSizing> _meshSizings;
             
-            vtkSmartPointer<vtkUnstructuredGrid> _gridData;
             vtkSmartPointer<vtkPolyData> _polyData;
-
+            vtkSmartPointer<vtkActor> _meshActor;
     };
+
+
+
+
+
 };
 
 

--- a/src/MeshCore/Mesh.h
+++ b/src/MeshCore/Mesh.h
@@ -1,11 +1,59 @@
 #ifndef MESH_H
 #define MESH_H
 
+#ifdef _WIN32
+#include <gmsh.h_cwrap>
+#endif
+
+#ifdef linux
+#include <gmsh.h>
+#endif
+
+#include <algorithm>
+#include <vector>
+
+#include <vtkActor.h>
+#include <vtkCellArray.h>
+#include <vtkPoints.h>
+#include <vtkPolyData.h>
+#include <vtkSmartPointer.h>
+#include <vtkUnstructuredGrid.h>
+#include <vtkDataSetMapper.h>
+#include <vtkIdTypeArray.h>
+
+
 namespace MeshCore{
 
     class Mesh{
         public:
+
+            Mesh(){};
+            ~Mesh(){};
+
+            vtkSmartPointer<vtkActor> getMeshActor(){return this->_meshActor;};
+
+            void addSizing(std::vector<int> nodeToSizeTags);
+            void genereateSurfaceMesh();
+            void generateVolumeMesh();
+
         private:
+            
+            void updateMeshActor();
+
+            enum class ElementType : int {
+                TETRA = 4,
+                TRIANGLE = 2,
+                LINE = 1,
+                POINT = 15,
+            };
+
+            vtkSmartPointer<vtkActor> _meshActor;
+
+            std::vector<std::pair<int, int>> _sizingTags;
+            
+            vtkSmartPointer<vtkUnstructuredGrid> _gridData;
+            vtkSmartPointer<vtkPolyData> _polyData;
+
     };
 };
 

--- a/src/MeshCore/Mesh.h
+++ b/src/MeshCore/Mesh.h
@@ -22,6 +22,7 @@
 #include <vtkProperty.h>
 #include <vtkPolyData.h>
 #include <vtkPolyDataMapper.h>
+#include <vtkUnstructuredGrid.h>
 
 namespace MeshCore{
     
@@ -35,29 +36,27 @@ namespace MeshCore{
     class Mesh{
         public:
             Mesh();
-            vtkSmartPointer<vtkActor> getMeshActor(){return this->_meshActor;};
             void addSizing(std::vector<int> verticesTags, double size);
-            void genereateSurfaceMesh();
+            void generateSurfaceMesh();
+            void generateVolumeMesh();
+
+            vtkSmartPointer<vtkPoints> getVtkPoints();
+            vtkSmartPointer<vtkCellArray> getVtkCellArray(ElementType ElementType);
+            vtkSmartPointer<vtkActor> getMeshActor(){return this->_meshActor;};
 
         private:
-            
+
+            void fillVtkPoints();
             void fillElementDataMap(ElementType elementType);
-            void fillVtkNodes();
-            void updatePolyData();
 
             vtkSmartPointer<vtkActor> createMeshActor(vtkSmartPointer<vtkPolyData> polyData);
-
-
             std::vector<MeshSizing> _meshSizings;
-            
-
             std::map<ElementType, vtkElementData> _elementDataMap;
 
-            vtkSmartPointer<vtkPoints> _vtkNodes;
+            vtkSmartPointer<vtkPoints> _vtkPoints;
             vtkSmartPointer<vtkPolyData> _polyData;
+            vtkSmartPointer<vtkUnstructuredGrid> _gridData;
             vtkSmartPointer<vtkActor> _meshActor;
     };
 };
-
-
 #endif

--- a/src/MeshCore/Mesh.h
+++ b/src/MeshCore/Mesh.h
@@ -1,6 +1,8 @@
 #ifndef MESH_H
 #define MESH_H
 
+#include "MeshContainers.hpp"
+
 #ifdef _WIN32
 #include <gmsh.h_cwrap>
 #endif
@@ -22,45 +24,39 @@
 #include <vtkPolyDataMapper.h>
 
 namespace MeshCore{
-
-    struct MeshSizing{
-        
-        MeshSizing(std::vector<int> verticesTags, double size);
-
-        double elementSize;
-        std::vector<std::pair<int, int>> nodeTags;
+    
+    enum class ElementType : int {
+        TETRA = 4,
+        TRIANGLE = 2,
+        LINE = 1,
+        POINT = 15,
     };
 
     class Mesh{
         public:
-
+            Mesh();
             vtkSmartPointer<vtkActor> getMeshActor(){return this->_meshActor;};
-
             void addSizing(std::vector<int> verticesTags, double size);
             void genereateSurfaceMesh();
 
         private:
             
-            vtkSmartPointer<vtkPolyData> createSurfaceMeshPolyData();
+            void fillElementDataMap(ElementType elementType);
+            void fillVtkNodes();
+            void updatePolyData();
 
             vtkSmartPointer<vtkActor> createMeshActor(vtkSmartPointer<vtkPolyData> polyData);
 
-            enum class ElementType : int {
-                TETRA = 4,
-                TRIANGLE = 2,
-                LINE = 1,
-                POINT = 15,
-            };
+
             std::vector<MeshSizing> _meshSizings;
             
+
+            std::map<ElementType, vtkElementData> _elementDataMap;
+
+            vtkSmartPointer<vtkPoints> _vtkNodes;
             vtkSmartPointer<vtkPolyData> _polyData;
             vtkSmartPointer<vtkActor> _meshActor;
     };
-
-
-
-
-
 };
 
 

--- a/src/MeshCore/MeshContainers.hpp
+++ b/src/MeshCore/MeshContainers.hpp
@@ -1,0 +1,37 @@
+#ifndef MESHCONTAINERS_H
+#define MESHCONTAINERS_H
+
+
+#include <vector>
+#include <vtkSmartPointer.h>
+#include <vtkActor.h>
+#include <vtkCellArray.h>
+
+namespace MeshCore{
+
+    struct MeshSizing{
+        
+        MeshSizing(std::vector<int> verticesTags, double size);
+
+        double elementSize;
+        std::vector<std::pair<int, int>> nodeTags;
+    };
+
+    struct vtkElementData {
+        vtkElementData() 
+            : nCellNodes(0), 
+            vtkCellType(0), 
+            vtkCells(vtkSmartPointer<vtkCellArray>::New()) {}
+
+        vtkElementData(int nNodes, int vtkType)
+            : nCellNodes(nNodes),
+            vtkCellType(vtkType),
+            vtkCells(vtkSmartPointer<vtkCellArray>::New()) {}
+
+    int nCellNodes;
+    vtkSmartPointer<vtkCellArray> vtkCells;
+    int vtkCellType;
+    };
+}
+
+#endif

--- a/src/MeshCore/MeshContainers.hpp
+++ b/src/MeshCore/MeshContainers.hpp
@@ -21,13 +21,16 @@ namespace MeshCore{
         vtkElementData() 
             : nCellNodes(0), 
             vtkCellType(0), 
-            vtkCells(vtkSmartPointer<vtkCellArray>::New()) {}
+            vtkCells(vtkSmartPointer<vtkCellArray>::New()),
+            filled(false) {}
 
         vtkElementData(int nNodes, int vtkType)
             : nCellNodes(nNodes),
             vtkCellType(vtkType),
-            vtkCells(vtkSmartPointer<vtkCellArray>::New()) {}
+            vtkCells(vtkSmartPointer<vtkCellArray>::New()),
+            filled(false) {}
 
+    bool filled;
     int nCellNodes;
     vtkSmartPointer<vtkCellArray> vtkCells;
     int vtkCellType;

--- a/src/Model/Model.cpp
+++ b/src/Model/Model.cpp
@@ -54,7 +54,7 @@ void Model::addSizing(std::vector<std::reference_wrapper<const TopoDS_Shape>> se
 }
 
 void Model::meshParts() {
-    this->mesh.genereateSurfaceMesh();
+    this->mesh.generateSurfaceMesh();
 }
 
 void Model::updateMeshActor(){

--- a/src/Model/Model.cpp
+++ b/src/Model/Model.cpp
@@ -176,10 +176,30 @@ void Model::updateMeshActor()
     this->meshActor->GetProperty()->SetEdgeColor(0.0, 0.0, 0.0);
 }
 
-void Model::addEdgeSizing(vtkSmartPointer<vtkActor> edgeActor){
-
-};
-
-void Model::addFaceSizing(vtkSmartPointer<vtkActor> faceActor){
-
-};
+void Model::addSizing(std::vector<std::reference_wrapper<const TopoDS_Shape>> selectedShapess){
+    
+    TopoDS_Shape ds_shape;
+    TopoDS_Face face;
+    std::vector<std::reference_wrapper<const TopoDS_Vertex>> vertices;
+    int tag;
+    for(const auto shape : selectedShapess){
+        std::cout<<"shape"<<std::endl;
+        switch (shape.get().ShapeType())
+        {
+        case TopAbs_FACE:
+            face = TopoDS::Face(shape.get());
+            vertices = GeometryCore::getShapeVertices(face);
+            for(auto vertex : vertices){
+                tag = this->geometry._tagMap.getTag(vertex.get());
+                std::cout<<"Vertex tag: "<< tag << std::endl;
+            }
+            break;
+        default:
+            tag = 0;
+            break;
+        }
+    }
+   
+   
+    std::cout<<"Imposing sizing on shapes!" << std::endl;
+}

--- a/src/Model/Model.cpp
+++ b/src/Model/Model.cpp
@@ -46,7 +46,7 @@ void Model::updateParts() {
 }
 
 void Model::meshParts() {
-            gmsh::option::setNumber("Mesh.MeshSizeMin", 0.05);
+            gmsh::option::setNumber("Mesh.MeshSizeMin", 0.1);
             gmsh::option::setNumber("Mesh.MeshSizeMax", 2);
             std::cout<<"sizing entities:" << std::endl;
             for(auto sizingTag : this->_sizingTags){
@@ -58,7 +58,7 @@ void Model::meshParts() {
             for(auto dimTag : dimTags){
                 std::cout << "Dim: " << dimTag.first << "Tag: " << dimTag.second << std::endl;
             } 
-            gmsh::model::mesh::setSize(this->_sizingTags, 0.05);
+            gmsh::model::mesh::setSize(this->_sizingTags, 0.1);
             std::cout << "Meshing..." << std::endl;
             gmsh::model::mesh::generate(3);
             // gmsh::write(_modelName + ".msh");

--- a/src/Model/Model.cpp
+++ b/src/Model/Model.cpp
@@ -32,17 +32,14 @@ Model::~Model(){
     gmsh::finalize();
 }
 
-void Model::updateParts() { 
-    GeometryCore::PartsMap partsMap = this->geometry.getShapesMap();
-    for (const auto& it : partsMap) {
+void Model::addShapesToModel(const GeometryCore::PartsMap& shapesMap) { 
+    for (const auto& it : shapesMap) {
         const auto& shape = it.second;
         const void *shape_ptr = &shape;
         std::vector< std::pair<int, int>> outDimTags;
         gmsh::model::occ::importShapesNativePointer(shape_ptr, outDimTags);
     }
-    std::cout << "Loaded " << partsMap.size() << " parts into the model!" << std::endl;
     gmsh::model::occ::synchronize();
-
 }
 
 void Model::addSizing(std::vector<std::reference_wrapper<const TopoDS_Shape>> selectedShapes){
@@ -53,10 +50,25 @@ void Model::addSizing(std::vector<std::reference_wrapper<const TopoDS_Shape>> se
     }
 }
 
-void Model::meshParts() {
-    this->mesh.generateSurfaceMesh();
+void Model::meshSurface() {
+    mesh.generateSurfaceMesh();
+}
+void Model::meshVolume(){
+    mesh.generateVolumeMesh();
+}
+            
+vtkSmartPointer<vtkActor> Model::getMeshActor(){
+    return mesh.getMeshActor();
 }
 
-void Model::updateMeshActor(){
-    this->meshActor = this->mesh.getMeshActor();
+void Model::importSTL(const std::string& filePath, QWidget* progressBar){
+    geometry.importSTL(filePath, progressBar);
+    GeometryCore::PartsMap shapesMap = geometry.getShapesMap();
+    addShapesToModel(shapesMap);
+}
+
+void Model::importSTEP(const std::string& filePath, QWidget* progressBar){
+    geometry.importSTEP(filePath, progressBar);
+    GeometryCore::PartsMap shapesMap = geometry.getShapesMap();
+    addShapesToModel(shapesMap);
 }

--- a/src/Model/Model.cpp
+++ b/src/Model/Model.cpp
@@ -25,7 +25,6 @@
 Model::Model(std::string modelName) : _modelName(modelName) {
         gmsh::initialize();
         gmsh::model::add(_modelName);
-        gmsh::option::setNumber("General.Terminal", 1);
         this->geometry = GeometryCore::Geometry();
         this->mesh = MeshCore::Mesh();
         };
@@ -43,147 +42,21 @@ void Model::updateParts() {
     }
     std::cout << "Loaded " << partsMap.size() << " parts into the model!" << std::endl;
     gmsh::model::occ::synchronize();
-}
 
-void Model::meshParts() {
-            gmsh::option::setNumber("Mesh.MeshSizeMin", 0.1);
-            gmsh::option::setNumber("Mesh.MeshSizeMax", 2);
-            gmsh::model::mesh::setSize(this->_sizingTags, 0.1);
-            gmsh::model::mesh::generate(3);
-            gmsh::write(_modelName + ".msh");
-            this->polyData = createMeshVtkPolyData();
-}
-
-vtkSmartPointer<vtkPolyData> Model::createMeshVtkPolyData() {
-    std::cout << "moving mesh to vtkPolyData..." << std::endl;
-
-    // extract nodes from gmsh model, and transfer them to vtkPoints container
-    // nodeTags is a vector containing node numbering (tag - hence the name)
-    // nodeCoords holds coordinates of each node [node_1_x, node_1_y, node_1_z, node_2_x, etc...]
-    #ifdef _WIN32
-    std::vector<unsigned long long> nodeTags;
-    #endif
-    #ifdef linux
-    std::vector<unsigned long> nodeTags;
-    #endif
-    std::vector<double> nodeCoords;
-    std::vector<double> parametricCoord;
-
-    gmsh::model::mesh::getNodes(nodeTags, nodeCoords, parametricCoord);
-
-    vtkSmartPointer<vtkPoints> vtkNodes = vtkSmartPointer<vtkPoints>::New();
-    int xNodeId, yNodeId, zNodeId;
-    for(size_t i = 0; i < nodeTags.size(); ++i)
-    {
-        xNodeId = i*3;
-        yNodeId = xNodeId + 1;
-        zNodeId = xNodeId + 2;
-        vtkNodes->InsertNextPoint(nodeCoords[xNodeId],
-                                    nodeCoords[yNodeId],
-                                    nodeCoords[zNodeId]);
-    }
-
-    // extract 3D elements from gmsh model, and transfer them to vtkCellArray container
-    // elementTypes is a vector containing types of elemnts in the mesh
-    // elementTags is a vevtor of length equal to elementTypes. It holds a vector of element
-    // ids (tags) for each element type. Ex elementTags[0].size() would return a total number
-    // of elements of type elementTags[0] (so far only tetras)
-    // elementNodeTags is a vevtor of length equal to elementTypes. For each type it stores
-    // a vector of node tags concatenated: [e1n1, e1n2, ..., e1nN, e2n1, ...]
-    // in our case we so far handle only tetrahedral elements (so 4 nodes per ele)
-
-    std::vector<int> _elementTypes;
-    std::vector<ElementType> elementTypes;
-
-    #ifdef _WIN32
-    std::vector<std::vector<unsigned long long>> elementTags;
-    std::vector<std::vector<unsigned long long>> elementNodeTags;
-    #endif
-    #ifdef linux
-    std::vector<std::vector<unsigned long>> elementTags;
-    std::vector<std::vector<unsigned long>> elementNodeTags;
-    #endif
-
-    gmsh::model::mesh::getElements(_elementTypes, elementTags, elementNodeTags, -1);
-
-    elementTypes.reserve(_elementTypes.size());
-    std::transform(_elementTypes.begin(), _elementTypes.end(), std::back_inserter(elementTypes),
-    [](int& elem){return static_cast<ElementType>(elem);});
-
-    struct ElementData {
-        ElementData() 
-            : nCellNodes(0), 
-            vtkCellType(0), 
-            vtkCells(vtkSmartPointer<vtkCellArray>::New()) {}
-
-        ElementData(int nNodes, int vtkType)
-            : nCellNodes(nNodes),
-            vtkCellType(vtkType),
-            vtkCells(vtkSmartPointer<vtkCellArray>::New()) {}
-
-    int nCellNodes;
-    vtkSmartPointer<vtkCellArray> vtkCells;
-    int vtkCellType;
-    };
-
-    std::map<ElementType, ElementData> elementDataMap = {
-        {ElementType::TETRA, {4, VTK_TETRA}},
-        {ElementType::TRIANGLE, {3, VTK_TRIANGLE}},
-        {ElementType::LINE, {2, VTK_LINE}}
-    };
-
-    this->gridData = vtkSmartPointer<vtkUnstructuredGrid>::New();
-    this->gridData->SetPoints(vtkNodes);
-    std::vector<vtkIdType> currentElementNodeTags;
-    for(size_t i = 0; i < elementTypes.size(); ++i)
-    {
-        if(elementTypes[i]!=ElementType::POINT){
-        ElementData elementData = elementDataMap.at(elementTypes[i]);
-        auto nElements = elementTags[i].size();
-        auto nNodes = elementData.nCellNodes;
-        auto cellArray = elementData.vtkCells;
-        auto cellType = elementData.vtkCellType;
-
-        for(size_t elementId = 0; elementId < nElements; ++elementId){
-            auto startNodeIterator = std::make_move_iterator(elementNodeTags[i].begin() + elementId * nNodes);
-            auto endNodeIterator = std::make_move_iterator(elementNodeTags[i].begin() + (elementId + 1) * nNodes);
-
-            std::transform(startNodeIterator, endNodeIterator, std::back_inserter(currentElementNodeTags),
-                [](auto nodeId) { return static_cast<vtkIdType>(nodeId - 1);});
-            cellArray->InsertNextCell(nNodes, currentElementNodeTags.data());
-            currentElementNodeTags.clear(); 
-        }
-        gridData->SetCells(cellType, cellArray);
-        }
-    }
-    vtkSmartPointer<vtkPolyData> polyData = vtkSmartPointer<vtkPolyData>::New();
-    polyData->SetPoints(vtkNodes);
-    polyData->SetLines(elementDataMap.at(ElementType::LINE).vtkCells);
-    polyData->SetPolys(elementDataMap.at(ElementType::TRIANGLE).vtkCells);
-    std::cout << "Succesfully created vtkPolyData object!" << std::endl;
-    return polyData;
-}
-
-
-void Model::updateMeshActor()
-{
-    vtkSmartPointer<vtkPolyDataMapper> mapper = vtkSmartPointer<vtkPolyDataMapper>::New();
-    mapper->SetInputData(this->polyData);
-    this->meshActor = vtkSmartPointer<vtkActor>::New();
-    this->meshActor->SetMapper(mapper);
-    this->meshActor->GetProperty()->EdgeVisibilityOn();
-    this->meshActor->GetProperty()->SetEdgeColor(0.0, 0.0, 0.0);
 }
 
 void Model::addSizing(std::vector<std::reference_wrapper<const TopoDS_Shape>> selectedShapes){
-    std::vector<std::pair<int, int>> sizingTags;
     for(const auto& shape : selectedShapes){
         const TopoDS_Shape& shapeRef =  shape.get();
         std::vector<int> vertexTags = geometry.getShapeVerticesTags(shape);
-        for(auto vertexTag : vertexTags){
-                std::pair<int, int> tagPair(0, vertexTag);
-                sizingTags.push_back(tagPair);
-            }
+        mesh.addSizing(vertexTags, 0.1);
     }
-    this->_sizingTags = sizingTags;
+}
+
+void Model::meshParts() {
+    this->mesh.genereateSurfaceMesh();
+}
+
+void Model::updateMeshActor(){
+    this->meshActor = this->mesh.getMeshActor();
 }

--- a/src/Model/Model.h
+++ b/src/Model/Model.h
@@ -46,6 +46,14 @@
 #include <vtkDataSetMapper.h>
 #include <vtkIdTypeArray.h>
 
+#include <TopExp.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopoDS_Face.hxx>
+#include <TopoDS_Edge.hxx>
+#include <TopoDS_Vertex.hxx>
+#include <BRep_Tool.hxx>
+
+
 class Model {
 public:
 	std::string _modelName;
@@ -60,8 +68,7 @@ public:
 	void meshParts();
 	void updateMeshActor();
 
-	void addFaceSizing(vtkSmartPointer<vtkActor> edgeActor);
-	void addEdgeSizing(vtkSmartPointer<vtkActor> faceActor);
+	void addSizing(std::vector<std::reference_wrapper<const TopoDS_Shape>> selectedShapes);
 
 	vtkSmartPointer<vtkPolyData> createMeshVtkPolyData();
 	vtkSmartPointer<vtkActor> meshActor;

--- a/src/Model/Model.h
+++ b/src/Model/Model.h
@@ -23,8 +23,6 @@
 #include "Geometry.h"
 #include "Mesh.h"
 
-#include <TopoDS_Shape.hxx>
-
 #ifdef _WIN32
 #include <gmsh.h_cwrap>
 #endif
@@ -34,28 +32,9 @@
 #endif
 
 
-#include <algorithm>
-#include <vector>
-
-#include <vtkActor.h>
-#include <vtkCellArray.h>
-#include <vtkPoints.h>
-#include <vtkPolyData.h>
-#include <vtkSmartPointer.h>
-#include <vtkUnstructuredGrid.h>
-#include <vtkDataSetMapper.h>
-#include <vtkIdTypeArray.h>
-
-#include <TopExp.hxx>
-#include <TopExp_Explorer.hxx>
-#include <TopoDS_Face.hxx>
-#include <TopoDS_Edge.hxx>
-#include <TopoDS_Vertex.hxx>
-#include <BRep_Tool.hxx>
-
 
 class Model {
-public:
+	public:
 	std::string _modelName;
 	GeometryCore::Geometry geometry;
 	MeshCore::Mesh mesh;
@@ -64,25 +43,15 @@ public:
 	~Model();
 
 	void updateParts();
-
 	void meshParts();
-	void updateMeshActor();
 
 	void addSizing(std::vector<std::reference_wrapper<const TopoDS_Shape>> selectedShapes);
-
-	vtkSmartPointer<vtkPolyData> createMeshVtkPolyData();
+    void updateMeshActor();
 	vtkSmartPointer<vtkActor> meshActor;
 
-private:
-	enum class ElementType : int {
-		TETRA = 4,
-		TRIANGLE = 2,
-		LINE = 1,
-		POINT = 15,
-	};
-	std::vector<std::pair<int, int>> _sizingTags;
-	vtkSmartPointer<vtkUnstructuredGrid> gridData;
-	vtkSmartPointer<vtkPolyData> polyData;
+	private:
+
+
 };
 
 #endif // MODEL_H

--- a/src/Model/Model.h
+++ b/src/Model/Model.h
@@ -80,6 +80,7 @@ private:
 		LINE = 1,
 		POINT = 15,
 	};
+	std::vector<std::pair<int, int>> _sizingTags;
 	vtkSmartPointer<vtkUnstructuredGrid> gridData;
 	vtkSmartPointer<vtkPolyData> polyData;
 };

--- a/src/Model/Model.h
+++ b/src/Model/Model.h
@@ -42,16 +42,20 @@ class Model {
 	Model(std::string modelName);
 	~Model();
 
-	void updateParts();
-	void meshParts();
+	//--------Geometry interface-----// 
+    void importSTEP(const std::string& filePath, QWidget* progressBar);
+    void importSTL(const std::string& filePath, QWidget* progressBar);
+
+	//--------Meshing interface-----// 
+	void meshSurface();
+	void meshVolume();
+	vtkSmartPointer<vtkActor> getMeshActor();
 
 	void addSizing(std::vector<std::reference_wrapper<const TopoDS_Shape>> selectedShapes);
-    void updateMeshActor();
-	vtkSmartPointer<vtkActor> meshActor;
+   
 
 	private:
-
-
+		void addShapesToModel(const GeometryCore::PartsMap& shapesMap);
 };
 
 #endif // MODEL_H

--- a/src/UserInterface/Core/MainWindow.cpp
+++ b/src/UserInterface/Core/MainWindow.cpp
@@ -110,7 +110,7 @@ void MainWindow::importSTEP(QString fileName) {
 	try {
 		this->model->geometry.importSTEP(filePath, this->progressBar);
 		this->model->updateParts();
-		GeometryCore::PartsMap shapesMap = this->model->geometry.getShapesMap();
+		const GeometryCore::PartsMap& shapesMap = model->geometry.getShapesMap();
 		for(auto shape : shapesMap){
 			this->QVTKRender->addShapeToRenderer(shape.second);
 		}

--- a/src/UserInterface/Core/MainWindow.cpp
+++ b/src/UserInterface/Core/MainWindow.cpp
@@ -108,8 +108,7 @@ void MainWindow::importSTEP(QString fileName) {
 	QPointer<ProgressBar> progressBar = this->getProgressBar();
 	const std::string& filePath = fileName.toStdString();
 	try {
-		this->model->geometry.importSTEP(filePath, this->progressBar);
-		this->model->updateParts();
+		this->model->importSTEP(filePath, this->progressBar);
 		const GeometryCore::PartsMap& shapesMap = model->geometry.getShapesMap();
 		for(auto shape : shapesMap){
 			this->QVTKRender->addShapeToRenderer(shape.second);
@@ -146,7 +145,7 @@ void MainWindow::newModel() {
 	ui->actionGenerateMesh->setEnabled(true);
 }
 void MainWindow::generateMesh() {
-	this->model->meshParts();
+	this->model->meshSurface();
 }
 //----------------------------------------------------------------------------
 void MainWindow::handleSelectorButtonClicked(QAbstractButton* button) {
@@ -168,11 +167,9 @@ void MainWindow::initializeActions() {
 }
 
 void MainWindow::showMesh() {
-	this->model->updateMeshActor();
 	this->QVTKRender->clearRenderer();
-	this->QVTKRender->addActor(this->model->meshActor);
+	this->QVTKRender->addActor(this->model->getMeshActor());
 	this->QVTKRender->RenderScene();
-	// this->QVTKRender->getActiveRenderer()->Render();
 }
 
 //----------------------------------------------------------------------------

--- a/src/UserInterface/Core/MainWindow.cpp
+++ b/src/UserInterface/Core/MainWindow.cpp
@@ -80,8 +80,12 @@ void MainWindow::setConnections() {
 	connect(ui->actionGenerateMesh, &QAction::triggered, [this]() {
 		generateMesh();
 	});
-	connect(ui->actionShowMesh, &QAction::triggered, [this]() {
-		showMesh();
+	connect(ui->actionShowMesh, &QAction::toggled, [this](bool checked) {
+		if (checked) {
+			showMesh();
+		} else {
+			showGeometry();
+		}
 	});
 
 	connect(this->ui->treeWidget, &QTreeWidget::itemSelectionChanged,
@@ -169,6 +173,11 @@ void MainWindow::initializeActions() {
 void MainWindow::showMesh() {
 	this->QVTKRender->clearRenderer();
 	this->QVTKRender->addActor(this->model->getMeshActor());
+	this->QVTKRender->RenderScene();
+}
+void MainWindow::showGeometry(){
+	this->QVTKRender->clearRenderer();
+	this->QVTKRender->addPipelinesToRenderer();
 	this->QVTKRender->RenderScene();
 }
 

--- a/src/UserInterface/Core/MainWindow.h
+++ b/src/UserInterface/Core/MainWindow.h
@@ -95,6 +95,11 @@ public:
 	void showMesh();
 
 	/**
+	 * @brief  When mesh view is disabled -> add Model geometry actor to renderer
+	 */
+	void showGeometry();
+
+	/**
 	 * @brief  Get access to progress bar.
 	 *
 	 * @return {ProgressBar*}  : Progress bar instance.

--- a/src/UserInterface/GraphicalUtils/TreeStructure.cpp
+++ b/src/UserInterface/GraphicalUtils/TreeStructure.cpp
@@ -117,7 +117,7 @@ void TreeStructure::loadGeometryFile(const QString fileName) {
 }
 
 //--------------------------------------------------------------------------------------
-void TreeStructure::addNode(const QString& parentLabel, const QString& fileName) {
+void TreeStructure::addNode(const QString& parentLabel, const QString& nodeName) {
 	QList<QTreeWidgetItem*> qlist
 		= this->findTreeWidgetItems(parentLabel, Qt::MatchExactly);
 
@@ -127,7 +127,7 @@ void TreeStructure::addNode(const QString& parentLabel, const QString& fileName)
 	}
 
 	QDomElement element = this->docObjectModel->createElement("group");
-	element.setAttribute("label", fileName);
+	element.setAttribute("label", nodeName);
 
 	if (domElements.contains(parentItem)) {
 		QDomElement* node = domElements.value(parentItem);
@@ -137,7 +137,7 @@ void TreeStructure::addNode(const QString& parentLabel, const QString& fileName)
 	}
 
 	auto item = this->createItem(&element, parentItem);
-	item->setText(static_cast<int>(Column::Label), fileName);
+	item->setText(static_cast<int>(Column::Label), nodeName);
 }
 
 //--------------------------------------------------------------------------------------

--- a/src/UserInterface/Rendering/QVTKInteractorStyle.cpp
+++ b/src/UserInterface/Rendering/QVTKInteractorStyle.cpp
@@ -171,7 +171,13 @@ void QVTKInteractorStyle::createContextMenu() {
 		QObject::connect(_fitViewAction, &QAction::triggered,
 			[this]() { _qvtkRenderWindow->fitView(); });
 
+		_addSizingAction = new QAction("Add sizing", _contextMenu);
+		QObject::connect(_addSizingAction, &QAction::triggered, 
+			[this]() {_qvtkRenderWindow->model->addSizing(this->_selectedShapes);});
+
 		_contextMenu->addAction(_fitViewAction);
+		_contextMenu->addAction(_addSizingAction);
+
 	}
 }
 
@@ -343,7 +349,7 @@ void QVTKInteractorStyle::OnSelection(const Standard_Boolean appendId) {
 			}
 
 			IVtk_IdType aShapeID = anOccShape->GetId();
-
+			
 			Handle(Message_Messenger) anOutput = Message::DefaultMessenger();
 			if (!_shapePipelinesMap.IsBound(aShapeID)) {
 				anOutput->SendWarning()
@@ -368,6 +374,7 @@ void QVTKInteractorStyle::OnSelection(const Standard_Boolean appendId) {
 			}
 
 			if (!appendId) {
+				_selectedShapes.clear();
 				selectedSubShapeIds->Clear();
 			}
 
@@ -391,6 +398,8 @@ void QVTKInteractorStyle::OnSelection(const Standard_Boolean appendId) {
 			IVtk_ShapeIdList::Iterator aMetaIds(*selectedSubShapeIds);
 			for (; aMetaIds.More(); aMetaIds.Next()) {
 				IVtk_ShapeIdList aSubSubIds = anOccShape->GetSubIds(aMetaIds.Value());
+				const TopoDS_Shape& aSubShape = anOccShape->GetSubShape(aMetaIds.Value());
+				_selectedShapes.push_back(aSubShape);
 				aSubIds.Append(aSubSubIds);
 			}
 

--- a/src/UserInterface/Rendering/QVTKInteractorStyle.cpp
+++ b/src/UserInterface/Rendering/QVTKInteractorStyle.cpp
@@ -110,7 +110,13 @@ NCollection_List<Handle(QIVtkSelectionPipeline)> QVTKInteractorStyle::getPipelin
 
 	return pipelineList;
 }
-
+void QVTKInteractorStyle::removePipelines() {
+    for (ShapePipelinesMap::Iterator it(_shapePipelinesMap); it.More(); it.Next()) {
+        const Handle(QIVtkSelectionPipeline)& pipeline = it.Value();
+		pipeline->Delete();
+    }
+    _shapePipelinesMap.Clear();
+}
 //----------------------------------------------------------------------------
 Standard_Integer QVTKInteractorStyle::getPipelinesMapSize() {
 	return _shapePipelinesMap.Size();

--- a/src/UserInterface/Rendering/QVTKInteractorStyle.h
+++ b/src/UserInterface/Rendering/QVTKInteractorStyle.h
@@ -25,6 +25,8 @@ namespace Rendering {
 class QVTKRenderWindow;
 };
 
+#include <functional>
+
 #include "QIVtkSelectionPipeline.h"
 #include "QVTKRenderWindow.h"
 
@@ -122,10 +124,12 @@ private:
 
 	void MoveTo(Standard_Integer, Standard_Integer);
 	void OnSelection(const Standard_Boolean = Standard_False);
+	std::vector<TopoDS_Shape> getVectorOfSelectedShapes();
 
 private:
 	QPointer<QMenu> _contextMenu;
 	QPointer<QAction> _fitViewAction;
+	QPointer<QAction> _addSizingAction;
 	// QPointer<QAction> _edgeSizingAction;
 
 	vtkSmartPointer<vtkRenderer> _renderer;
@@ -135,6 +139,8 @@ private:
 	ShapePipelinesMap _shapePipelinesMap;
 	SelectedSubShapeIdsMap _selectedSubShapeIdsMap;
 	IVtk_SelectionMode _currentSelection;
+
+	std::vector<std::reference_wrapper<const TopoDS_Shape>> _selectedShapes;
 };
 
 #endif

--- a/src/UserInterface/Rendering/QVTKInteractorStyle.h
+++ b/src/UserInterface/Rendering/QVTKInteractorStyle.h
@@ -83,6 +83,7 @@ public:
 	void setSelectionMode(IVtk_SelectionMode);
 	Standard_Integer getPipelinesMapSize();
 	NCollection_List<Handle(QIVtkSelectionPipeline)> getPipelines();
+	void removePipelines();
 
 	// Overriding
 public:

--- a/src/UserInterface/Rendering/QVTKRenderWindow.cpp
+++ b/src/UserInterface/Rendering/QVTKRenderWindow.cpp
@@ -137,6 +137,7 @@ void Rendering::QVTKRenderWindow::enableWaterMark() {
 //----------------------------------------------------------------------------
 void Rendering::QVTKRenderWindow::clearRenderer() {
 	this->_renderer->Clear();
+	this->_renderer->RemoveActor(this->model->getMeshActor());
 
 	NCollection_List<Handle(QIVtkSelectionPipeline)> pipelinesList
 		= _interactorStyle->getPipelines();
@@ -180,11 +181,23 @@ void Rendering::QVTKRenderWindow::addShapeToRenderer(const TopoDS_Shape& shape) 
 	static Standard_Integer ShapeID
 		= _interactorStyle->getPipelinesMapSize();
 	++ShapeID;
-	QIVtkSelectionPipeline* pipeline = new QIVtkSelectionPipeline(shape, ShapeID);
+
+	Handle(QIVtkSelectionPipeline) pipeline = new QIVtkSelectionPipeline(shape, ShapeID);
 	pipeline->AddToRenderer(_renderer);
 
 	_interactorStyle->addPipeline(pipeline, ShapeID);
 	fitView();
+}
+
+//----------------------------------------------------------------------------
+void Rendering::QVTKRenderWindow::addPipelinesToRenderer() {
+	NCollection_List<Handle(QIVtkSelectionPipeline)> pipelinesList
+		= _interactorStyle->getPipelines();
+	NCollection_List<Handle(QIVtkSelectionPipeline)>::Iterator pIt(pipelinesList);
+	for (; pIt.More(); pIt.Next()) {
+		const Handle(QIVtkSelectionPipeline)& pipeline = pIt.Value();
+		pipeline->AddToRenderer(_renderer);
+	}
 }
 
 //----------------------------------------------------------------------------

--- a/src/UserInterface/Rendering/QVTKRenderWindow.h
+++ b/src/UserInterface/Rendering/QVTKRenderWindow.h
@@ -121,6 +121,12 @@ public:
 	void addShapeToRenderer(const TopoDS_Shape& shape);
 
 	/**
+	 * @brief  Add existing pipelines to renderer window
+	 *
+	 */
+	void addPipelinesToRenderer();
+
+	/**
 	 * @brief  Clear rendering window.
 	 *
 	 */
@@ -150,6 +156,7 @@ private:
 
 	// IVtk_ShapePicker from OCC VIS
 	vtkSmartPointer<IVtkTools_ShapePicker> _shapePicker;
+
 
 	// Widget for displaying global coordinate system
 	vtkSmartPointer<vtkOrientationMarkerWidget> _vtkAxesWidget;

--- a/src/UserInterface/Rendering/QVTKRenderWindow.h
+++ b/src/UserInterface/Rendering/QVTKRenderWindow.h
@@ -25,8 +25,6 @@ class QVTKInteractorStyle;
 
 #include "QVTKInteractorStyle.h"
 
-#include "Geometry.h"
-#include "Mesh.h"
 #include "Model.h"
 
 #include <algorithm>

--- a/src/UserInterface/Widgets/RibbonBarWidget.cpp
+++ b/src/UserInterface/Widgets/RibbonBarWidget.cpp
@@ -82,6 +82,8 @@ void RibbonBarWidget::buildRibbon(SARibbonBar* bar) {
 	elementSizeAct->setIconText("Element Size");
 	sizeFieldGroup->addAction(elementSizeAct); // Dodanie akcji do grupy
 	sizeFieldPanel->addLargeAction(elementSizeAct);
+	connect(sizeFieldGroup, &QActionGroup::triggered, this,
+	&RibbonBarWidget::onPressedSizeField);
 
 	SARibbonCategory* page3 = new SARibbonCategory();
 	page3->setCategoryName("Display");
@@ -187,5 +189,13 @@ void RibbonBarWidget::onEntitySelectionChanged(QAction* action) {
 		_QVTKRender->setSelectionMode(IVtk_SelectionMode::SM_Face);
 	} else if (actionText == "Volume") {
 		_QVTKRender->setSelectionMode(IVtk_SelectionMode::SM_Shape);
+	}
+}
+
+void RibbonBarWidget::onPressedSizeField(QAction* action){
+	const QString& actionText = action->text();
+	
+	if (actionText == "elementSize"){
+		// this->_QVTKRender->model->addEdgeSizing()
 	}
 }

--- a/src/UserInterface/Widgets/RibbonBarWidget.cpp
+++ b/src/UserInterface/Widgets/RibbonBarWidget.cpp
@@ -66,10 +66,22 @@ void RibbonBarWidget::buildRibbon(SARibbonBar* bar) {
 	pannel2->addLargeAction(createAction("setting", ":/icons/icons/customize0.svg"));
 	pannel2->addLargeAction(createAction("windowsflag", ":/icons/icons/windowsflag-normal.svg"));
 	bar->addCategoryPage(page1);
-
+	
 	SARibbonCategory* page2 = new SARibbonCategory();
 	page2->setCategoryName("Mesh");
 	bar->addCategoryPage(page2);
+
+	SARibbonPannel* sizeFieldPanel
+		= new SARibbonPannel("Size fields", page2);
+	page2->addPannel(sizeFieldPanel);
+
+	QActionGroup* sizeFieldGroup = new QActionGroup(this);
+	sizeFieldGroup->setExclusive(true);
+
+	QAction* elementSizeAct = createAction("elementSize", ":/icons/icons/Selection_face.svg");
+	elementSizeAct->setIconText("Element Size");
+	sizeFieldGroup->addAction(elementSizeAct); // Dodanie akcji do grupy
+	sizeFieldPanel->addLargeAction(elementSizeAct);
 
 	SARibbonCategory* page3 = new SARibbonCategory();
 	page3->setCategoryName("Display");

--- a/src/UserInterface/Widgets/RibbonBarWidget.h
+++ b/src/UserInterface/Widgets/RibbonBarWidget.h
@@ -52,6 +52,7 @@ private:
 private slots:
 	void onRibbonThemeComboBoxCurrentIndexChanged(int index);
 	void onEntitySelectionChanged(QAction*);
+	void onPressedSizeField(QAction* action);
 
 private:
 	MainWindow* _mainWindow;


### PR DESCRIPTION
Changes:
 - Implemented Add sizing action (temporarily under right click).
 -  All meshing code was moved to mesh class. 
 - The model class was reworked to serve as an interface between mainwindow and geometry/.mesh.
 - Added addPipelinesToRenderer() method in QVTKRendererWindow to allow for toggling mesh/geo view.

next PR will include mesh settings and sizings in treeWidget. 